### PR TITLE
DSP-1479: Make initial delay unconditional

### DIFF
--- a/src/java/org/apache/cassandra/auth/Auth.java
+++ b/src/java/org/apache/cassandra/auth/Auth.java
@@ -123,23 +123,24 @@ public class Auth
      */
     public static void setup()
     {
+        // ALL THE HACKS BELOW WILL BE REMOVED ONCE DSP-1379 IS REVERTED
+
         // Issue: if a node is a seed (or is already bootstrapped), then there is no delay to see the peers.
         // A fresh new node starts up, sees that it's the only node in the ring and it doesn't yet have dse_auth keyspace.
         // But by the time that keyspace creation gets to validating schema agreement, its peers are up, and schema versions don't
         // match, and an SDE is thrown since validateSchemaAgreement() fails.
         // Solution: add a small delay so that even if the node is a seed, it'll still wait a little for its peers to show
         // up and sync schema.
-        if (!isSchemaCreated())
+        // Another issue is default superuser setup. We have to check if any users exist, and if not - insert one
+        // ('cassandra'). For this we also need peers to show up.
+        logger.info("Waiting 5 seconds for peers to show up before setting up auth");
+        try
         {
-            logger.info("Waiting 5 seconds for peers to show up before setting up auth schema");
-            try
-            {
-                TimeUnit.MILLISECONDS.sleep(5000);
-            }
-            catch (InterruptedException e)
-            {
-                throw new AssertionError(e);
-            }
+            TimeUnit.MILLISECONDS.sleep(5000);
+        }
+        catch (InterruptedException e)
+        {
+            throw new AssertionError(e);
         }
 
         // A temporary hack to reduce the possibility of SchemaDisagreementException during auth keyspace and cfs


### PR DESCRIPTION
A temporary measure to unblock DSP-1479. All of those ugly hacks will be dropped altogether once 1379 is 'reverted' - there is more to it than just reverting, but nvm.
